### PR TITLE
Allow proxy bypass

### DIFF
--- a/web/html/index.html
+++ b/web/html/index.html
@@ -146,8 +146,11 @@ window.onload = function() {
         </div>
         <div id="conPan" class="container col-11 align-self-center" > 
           <div class="row" >
-            <input id="hostInp" type="text" placeholder="Host to Connect" class="form-control col-10" value="testssh">
+            <input id="hostInp" type="text" placeholder="Host to Connect" class="form-control col-8" value="testssh">
             <input id="portInp" type="number" placeholder="Port" class="form-control col-2" value="22">
+            <label class="col-2">
+              <input id="bypassProxyInp" type="checkbox" /> Bypass proxy
+            </label>
           </div>
           <div class="row">
               <input id="usrInp" type="text" placeholder="User" class="form-control col-4" value="root">
@@ -161,7 +164,7 @@ window.onload = function() {
           </div>
           <div class="row"> 
               <button id="conBtn" type="button" class="btn btn-primary col-3" 
-                onclick="initConnection(term.rows, term.cols,$('#hostInp').val(),Number($('#portInp').val()),$('#usrInp').val(),$('#passInp').val(),$('#pkInp').val());">Connect</button>
+                onclick="initConnection(term.rows, term.cols,$('#hostInp').val(),Number($('#portInp').val()),$('#usrInp').val(),$('#passInp').val(),$('#pkInp').val(), $('#bypassProxyInp').is(':checked'), false);">Connect</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Add option to bypass the built-in web socket proxy and connect directly to the provided host/port, which would need to itself be a web socket.
- This is useful for anyone who has their own proxy solution in place already
- Also adds a parameter to the 'init' function to allow the fingerprint verification step to be bypassed

<img width="946" alt="Screen Shot 2022-10-12 at 9 39 04 PM" src="https://user-images.githubusercontent.com/85312004/195486777-91612175-2e26-45b3-8818-9c72b5dceff5.png">
