### PR TITLE
proxy: introduce separate connection log

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,12 @@ services:
       context: ./proxy
       dockerfile: Dockerfile
     hostname: proxy
+    volumes:
+      - ./proxy/logs/:/logs/
+    command:
+      - './proxy'
+      - '-al'
+      - '/logs/connections.log'
     ports:
       - 6666:6666
     restart: always

--- a/proxy/admin.go
+++ b/proxy/admin.go
@@ -20,19 +20,19 @@ var (
 	totalConnectionRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "connection_requests_total",
 		Help: "The total number of connection requests",
-	}, []string{"host", "src"})
+	}, []string{"host"})
 	totalBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "bytes_total",
 		Help: "The total number of bytes proxied",
-	}, []string{"host", "src", "dst", "dir"})
+	}, []string{"host", "dir"})
 	totalConnections = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "connections_total",
 		Help: "The total number of connections",
-	}, []string{"host", "src", "dst"})
+	}, []string{"host"})
 	activeConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "connections_active",
 		Help: "The current number of active connections",
-	}, []string{"host", "src", "dst"})
+	}, []string{"host"})
 	svcHost string
 )
 


### PR DESCRIPTION
for audit purpose a dedicated connection log was introduced. connection related data was removed from metrics labels to reduce cardinality.